### PR TITLE
Update Demo Charge to Resolve Bug

### DIFF
--- a/src/packs/heavy/Demo Charge.yml
+++ b/src/packs/heavy/Demo Charge.yml
@@ -31,7 +31,7 @@ data:
     ac: 15
     dmg: 0
   skill: ''
-  stat: '-'
+  stat: str
   tl: 3
 name: Demo Charge
 type: weapon


### PR DESCRIPTION
Have it use a initialized stat 'str', instead of a undefined '-' variable that would crash the sheet when it was Readied.

This flies in the face of the system, since Demo Charges uses no attributes to attack, but until a saving throw function is added to the weapon's template, this will have to do.